### PR TITLE
Dismissable notifications

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/MainActivity.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/MainActivity.java
@@ -447,10 +447,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     WifiManager wifiManager = (WifiManager) this.getSystemService(WIFI_SERVICE);
                     wifiManager.setWifiEnabled(false);
                 }
-                createNotification("Work session in progress.");
+                createNotification("Work session in progress.", true);
                 break;
             case ACTIVE_BREAK:
-                createNotification("Break session in progress.");
+                createNotification("Break session in progress.", true);
         }
         loadRunningTimerUIState();
 
@@ -487,7 +487,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     mTimer.cancel();
                     mTimer.purge();
                 }
-                createNotification("Work session is paused. Resume?");
+                createNotification("Work session is paused. Resume?", false);
                 break;
             case PAUSED_WORK:
                 mTimerState = TimerState.ACTIVE_WORK;
@@ -593,7 +593,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 mAlertDialog = alertDialogBuilder.create();
                 mAlertDialog.setCanceledOnTouchOutside(false);
                 mAlertDialog.show();
-                createNotification("Session complete. Continue?");
+                createNotification("Session complete. Continue?", false);
                 break;
             case ACTIVE_BREAK:
             case FINISHED_BREAK:
@@ -622,7 +622,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 mAlertDialog = alertDialogBuilder.create();
                 mAlertDialog.setCanceledOnTouchOutside(false);
                 mAlertDialog.show();
-                createNotification("Break complete. Resume work?");
+                createNotification("Break complete. Resume work?", false);
                 break;
             default:
                 mTimerState = TimerState.INACTIVE;
@@ -694,7 +694,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         }
     }
 
-    private void createNotification(CharSequence contentText) {
+    private void createNotification(CharSequence contentText, boolean ongoing) {
 
         Notification.Builder notificationBuilder = new Notification.Builder(
                 getApplicationContext())
@@ -702,7 +702,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 .setAutoCancel(false)
                 .setContentTitle("Goodtime")
                 .setContentText(contentText)
-                .setOngoing(true)
+                .setOngoing(ongoing)
                 .setShowWhen(false);
         notificationBuilder.setContentIntent(PendingIntent.getActivity(getApplicationContext(), 0,
                 new Intent(getApplicationContext(), MainActivity.class), PendingIntent.FLAG_UPDATE_CURRENT));

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Sat Sep 03 17:18:17 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
When a session ends, I don't always want to open the Goodtime app--for example, when I'm about to go to lunch or at the end of the day. This PR makes these notifications (but not the ones about in-progress sessions or breaks) dismissable.