### PR TITLE
Migrate from old settings

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/MainActivity.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/MainActivity.java
@@ -128,11 +128,17 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         super.onCreate(savedInstanceState);
 
         mPref = setUpPreferences();
+        migrateOldPreferences();
         installCustomRingtones();
         setUpUi();
         loadInitialState();
         setUpAndroidNougatSettings();
         setupBroadcastReceiver();
+    }
+
+    private void migrateOldPreferences() {
+        SharedPreferences oldPref = PreferenceManager.getDefaultSharedPreferences(this);
+        mPref.migrateFromOldPreferences(oldPref);
     }
 
     @Override

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
@@ -20,7 +20,8 @@ public class Notifications {
     public static Notification createCompletionNotification(
             Context context,
             SessionType sessionType,
-            String notificationSound
+            String notificationSound,
+            boolean vibrate
     ) {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
         if (!notificationSound.equals("")) {
@@ -30,8 +31,10 @@ public class Notifications {
                 builder.setSound(Uri.parse(notificationSound));
             }
         }
+        if(vibrate) {
+            builder.setVibrate(new long[]{0, 300, 700, 300});
+        }
         builder.setSmallIcon(R.drawable.ic_status_goodtime)
-               .setVibrate(new long[]{0, 300, 700, 300})
                .setLights(WHITE, 250, 750)
                .setContentTitle(context.getString(R.string.dialog_session_message))
                .setContentText(buildCompletedNotificationText(context, sessionType))

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Preferences.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Preferences.java
@@ -1,30 +1,42 @@
 package com.apps.adrcotfas.goodtime;
 
 import android.content.SharedPreferences;
+import android.util.Log;
+
 import com.apps.adrcotfas.goodtime.settings.CustomNotification;
 
 public class Preferences {
+
+    public static final String PREFERENCES_NAME = "com.apps.adrcotfas.goodtime.preferences";
+    private static final String TAG = "Preferences";
+    private static final int CURRENT_SETTINGS_VERSION = 2;
+
+    public static final String FIRST_RUN = "pref_firstRun";
+    public static final String SESSION_DURATION = "pref_workTime";
+    public static final String DISABLE_SOUND_AND_VIBRATION = "pref_disableSoundAndVibration";
+    public static final String NOTIFICATION_SOUND = "pref_notificationSound";
+    public static final String TOTAL_SESSION_COUNT = "pref_totalSessions";
+    private static final String BREAK_DURATION = "pref_breakTime";
+    private static final String LONG_BREAK_DURATION = "pref_longBreakDuration";
+    private static final String SESSIONS_BEFORE_LONG_BREAK = "pref_sessionsBeforeLongBreak";
+    private static final String SETTINGS_VERSION = "pref_settings_version";
+    private static final String DISABLE_WIFI = "pref_disableWifi";
+    private static final String KEEP_SCREEN_ON = "pref_keepScreenOn";
+    private static final String CONTINUOUS_MODE = "pref_continuousMode";
+    private static final String NOTIFICATION_VIBRATE = "pref_vibrate";
+    private static final String ROTATE_TIME_LABEL = "pref_rotate";
+
     private final SharedPreferences mPref;
 
     public Preferences(SharedPreferences pref) {
         mPref = pref;
+
+        if (pref.getInt(SETTINGS_VERSION, 0) == 0) {
+            mPref.edit()
+                 .putInt(SETTINGS_VERSION, CURRENT_SETTINGS_VERSION)
+                 .apply();
+        }
     }
-
-    public static final String PREFERENCES_NAME = "com.apps.adrcotfas.goodtime.preferences";
-
-    public static final String FIRST_RUN                    = "pref_firstRun";
-    public static final String SESSION_DURATION             = "pref_workTime";
-    public static final String BREAK_DURATION               = "pref_breakTime";
-    public static final String LONG_BREAK_DURATION          = "pref_longBreakDuration";
-    public static final String SESSIONS_BEFORE_LONG_BREAK   = "pref_sessionsBeforeLongBreak";
-    public static final String DISABLE_SOUND_AND_VIBRATION  = "pref_disableSoundAndVibration";
-    public static final String DISABLE_WIFI                 = "pref_disableWifi";
-    public static final String KEEP_SCREEN_ON               = "pref_keepScreenOn";
-    public static final String CONTINUOUS_MODE              = "pref_continuousMode";
-    public static final String NOTIFICATION_VIBRATE         = "pref_vibrate";
-    public static final String ROTATE_TIME_LABEL            = "pref_rotate";
-    public static final String NOTIFICATION_SOUND           = "pref_notificationSound";
-    public static final String TOTAL_SESSION_COUNT          = "pref_totalSessions";
 
     public boolean getRingtonesCopied() {
         return mPref.getBoolean(CustomNotification.PREF_KEY_RINGTONES_COPIED, false);
@@ -66,7 +78,9 @@ public class Preferences {
         return mPref.getBoolean(NOTIFICATION_VIBRATE, true);
     }
 
-    public boolean getRotateTimeLabel() {return mPref.getBoolean(ROTATE_TIME_LABEL, true); }
+    public boolean getRotateTimeLabel() {
+        return mPref.getBoolean(ROTATE_TIME_LABEL, true);
+    }
 
     public String getNotificationSound() {
         return mPref.getString(NOTIFICATION_SOUND, "");
@@ -74,5 +88,29 @@ public class Preferences {
 
     public void setDisableSoundAndVibration(boolean disableSoundAndVibration) {
         mPref.edit().putBoolean(DISABLE_SOUND_AND_VIBRATION, disableSoundAndVibration).apply();
+    }
+
+    public void migrateFromOldPreferences(SharedPreferences oldPref) {
+        if(oldPref.getBoolean(SESSION_DURATION, true)) {
+            return;
+        }
+
+        Log.i(TAG, "Migrating settings");
+
+        mPref.edit()
+             .putInt(SESSION_DURATION, oldPref.getInt(SESSION_DURATION, 25))
+             .putInt(SESSIONS_BEFORE_LONG_BREAK, oldPref.getInt(SESSIONS_BEFORE_LONG_BREAK, 4))
+             .putInt(BREAK_DURATION, oldPref.getInt(BREAK_DURATION, 5))
+             .putInt(LONG_BREAK_DURATION, oldPref.getInt(LONG_BREAK_DURATION, 15))
+             .putBoolean(KEEP_SCREEN_ON, oldPref.getBoolean(KEEP_SCREEN_ON, false))
+             .putBoolean(DISABLE_SOUND_AND_VIBRATION, oldPref.getBoolean(DISABLE_SOUND_AND_VIBRATION, false))
+             .putBoolean(DISABLE_WIFI, oldPref.getBoolean(DISABLE_WIFI, false))
+             .putBoolean(CONTINUOUS_MODE, oldPref.getBoolean(CONTINUOUS_MODE, false))
+             .putBoolean(NOTIFICATION_VIBRATE, oldPref.getBoolean(NOTIFICATION_VIBRATE, false))
+             .putBoolean(ROTATE_TIME_LABEL, oldPref.getBoolean(ROTATE_TIME_LABEL, true))
+             .putString(NOTIFICATION_SOUND, oldPref.getString(NOTIFICATION_SOUND, ""))
+             .apply();
+
+        oldPref.edit().clear().apply();
     }
 }

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/TimerService.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/TimerService.java
@@ -220,10 +220,14 @@ public class TimerService extends Service {
         NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         mNotificationManager.notify(
                 NOTIFICATION_TAG,
-                createCompletionNotification(this, mCurrentSession, mPref.getNotificationSound())
+                createCompletionNotification(
+                        this,
+                        mCurrentSession,
+                        mPref.getNotificationSound(),
+                        mPref.getNotificationVibrate()
+                )
         );
     }
-
 
     private void sendUpdateIntent() {
         Intent remainingTimeIntent = new Intent(ACTION_TIMERSERVICE);


### PR DESCRIPTION
This branch introduces a mechanism to migrate from the old settings to the new ones (that can be used by both `MainActivity` and `TimerService`). It also sets a settings version so that we can similarly migrate settings in future versions.

It also fixes a bug where the vibration setting was ignored in the notification.