### PR TITLE
Fix preferences migration bug

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/MainActivity.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/MainActivity.java
@@ -128,8 +128,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         super.onCreate(savedInstanceState);
 
         mPref = setUpPreferences();
-        // TODO: uncomment when fixed
-        //migrateOldPreferences();
+        migrateOldPreferences();
         installCustomRingtones();
         setUpUi();
         loadInitialState();

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Preferences.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Preferences.java
@@ -91,7 +91,7 @@ public class Preferences {
     }
 
     public void migrateFromOldPreferences(SharedPreferences oldPref) {
-        if(oldPref.getBoolean(SESSION_DURATION, true)) {
+        if(oldPref.getInt(SESSION_DURATION, -1) == -1) {
             return;
         }
 


### PR DESCRIPTION
For some stupid reason I fetched an integer as a boolean. And of course it fails. Sorry.