### PR TITLE
Rename 'Continuous mode' to 'No breaks between sessions'

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="pause">"PAUSE"</string>
     <string name="play_intro">"A pomodoro timer designed to keep you on track and free of distractions."</string>
     <string name="pref_break_duration">"Break duration"</string>
-    <string name="pref_continuous_mode">"Continuous mode"</string>
+    <string name="pref_continuous_mode">"No breaks between sessions"</string>
     <string name="pref_counter">"Sessions counter"</string>
     <string name="pref_disable_sound">"Disable sound and vibration"</string>
     <string name="pref_disable_wifi">"Disable Wi-Fi"</string>


### PR DESCRIPTION
I think users might not understand how a 'Continuous mode' work just by looking at the name. I initially thought it would disable the pause feature (=break sessions stay, but you cannot stop a work session without abandoning it).

'No breaks between sessions' sounds less ambiguous to me. Another candidate might be 'No-break mode'.