### PR TITLE
Extend notifications for android wear support

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
@@ -60,12 +60,20 @@ public final class Notifications {
                 .setAutoCancel(true);
 
         if(addButtons) {
+            NotificationCompat.WearableExtender extender = new NotificationCompat.WearableExtender();
             if (isWorkingSession(sessionType)) {
-                builder.addAction(createStartBreakAction(context))
-                        .addAction(createSkipBreakAction(context));
+                NotificationCompat.Action startBreakAction = createStartBreakAction(context);
+                NotificationCompat.Action skipBreakAction = createSkipBreakAction(context);
+                builder.addAction(startBreakAction)
+                        .addAction(skipBreakAction);
+                extender.addAction(startBreakAction)
+                        .addAction(skipBreakAction);
             } else {
-                builder.addAction(createStartWorkAction(context));
+                NotificationCompat.Action startWorkAction = createStartWorkAction(context);
+                builder.addAction(startWorkAction);
+                extender.addAction(startWorkAction);
             }
+            builder.extend(extender);
         }
         return builder.build();
     }

--- a/app/src/main/res/xml/about_contributors.xml
+++ b/app/src/main/res/xml/about_contributors.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <Preference
+        android:key="edio"
+        android:icon="@drawable/ic_code"
+        android:title="Dmytro Kostiuchenko">
+    </Preference>
+
+    <Preference
         android:key="fdw"
         android:icon="@drawable/ic_code"
         android:title="Fabian Winter">

--- a/contributors.md
+++ b/contributors.md
@@ -2,6 +2,7 @@
 
 Name | type |
 --- | --- |
+Dmytro Kostiuchenko | :bulb: |
 Fabian Winter | :bulb: |
 Wolfgang Faust | :bulb: |
 Fabian Winter | :de: |


### PR DESCRIPTION
This PR adds notification actions on android wear.
Works perfectly on my Pebble.

I do not own _true_ Android Wear device and thus can not test with it. But I see no reason, why it shouldn't work.

Also I took the liberty of adding myself to the contributors list (`about_contributors.xml` doesn't seem to be used, but added there too anyway). Hope it's not an issue, regardless the size of my contribution ;)