### PR TITLE
Correct the title in the break alert dialog

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
@@ -73,7 +73,6 @@ public final class Notifications {
             } else {
                 NotificationCompat.Action startWorkAction = createStartWorkAction(context);
                 builder.addAction(startWorkAction);
-
                 extender.addAction(startWorkAction);
             }
             builder.extend(extender);

--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Notifications.java
@@ -50,7 +50,7 @@ public final class Notifications {
                 .setPriority(PRIORITY_HIGH)
                 .setVisibility(VISIBILITY_PUBLIC)
                 .setLights(WHITE, 250, 750)
-                .setContentTitle(context.getString(R.string.dialog_session_message))
+                .setContentTitle(buildCompletedNotificationTitle(context, sessionType))
                 .setContentText(buildCompletedNotificationText(context, sessionType))
                 .setContentIntent(
                         getActivity(
@@ -73,6 +73,7 @@ public final class Notifications {
             } else {
                 NotificationCompat.Action startWorkAction = createStartWorkAction(context);
                 builder.addAction(startWorkAction);
+
                 extender.addAction(startWorkAction);
             }
             builder.extend(extender);
@@ -88,6 +89,17 @@ public final class Notifications {
             }
         }
         return builder.build();
+    }
+
+    private static CharSequence buildCompletedNotificationTitle(Context context, SessionType sessionType) {
+        switch (sessionType) {
+            case BREAK:
+            case LONG_BREAK:
+                return context.getString(R.string.dialog_break_message);
+            case WORK:
+            default:
+                return context.getString(R.string.dialog_session_message);
+        }
     }
 
     private static CharSequence buildCompletedNotificationText(Context context, SessionType sessionType) {


### PR DESCRIPTION
After a completed break, the wrong message was shown in the title of the alert dialog. 
I tried to correct that with a new method which updates the title message for both session types BREAK and LONG_BREAK. 