### PR TITLE
short flashing notification for automatic long break

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Main/TimerActivity.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Main/TimerActivity.java
@@ -364,7 +364,7 @@ public class TimerActivity
         // comes together with a "bring activity on top"
         if (PreferenceHelper.isFlashingNotificationEnabled() && mViewModel.enableFlashingNotification) {
             mWhiteCover.setVisibility(View.VISIBLE);
-            if ((PreferenceHelper.isAutoStartBreak() && mCurrentSessionType == SessionType.BREAK)
+            if ((PreferenceHelper.isAutoStartBreak() && (mCurrentSessionType == SessionType.BREAK || mCurrentSessionType == SessionType.LONG_BREAK))
                     || (PreferenceHelper.isAutoStartWork() && mCurrentSessionType == SessionType.WORK)) {
                 startFlashingNotificationShort();
             } else {


### PR DESCRIPTION
When long breaks and auto start break are activated, the app will start a long flashing notification when entering a long break.
This commit changes the condition so that a short flashing notification is started instead.