### PR TITLE
Force prompt to be cleared when starting a new session from notification

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/goodtime/Main/TimerActivity.java
+++ b/app/src/main/java/com/apps/adrcotfas/goodtime/Main/TimerActivity.java
@@ -543,6 +543,7 @@ public class TimerActivity
             if (mDialogSessionFinished != null) {
                 mDialogSessionFinished.dismissAllowingStateLoss();
             }
+            mViewModel.showFinishDialog = false;
             if (!PreferenceHelper.isAutoStartBreak() && !PreferenceHelper.isAutoStartWork()) {
                 stopFlashingNotification();
             }


### PR DESCRIPTION
This pr fixes #230.

Bug replication:

![goodtimebug](https://user-images.githubusercontent.com/8877057/113955798-004fcc00-984f-11eb-80a9-b48f76c69811.gif)

When `FinishWorkEvent` or `FinishBreakEvent` triggers while the app is in the background it 'queues' the dialog to be displayed when the app is foregrounded. However, once a `StartSessionEvent` is triggered from the notification this queued dialog isn't un-queued and will still appear when the app is foregrounded.

p.s. Thanks for maintaining this app! It's been great to use. 