### PR TITLE
build: fix jcenter dependency fail for kotlinx-html-js

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.jaredsburrows:gradle-license-plugin:0.8.90'
+        classpath 'com.jaredsburrows:gradle-license-plugin:0.8.91'
     }
 }
 
@@ -23,8 +23,8 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven { url 'https://jitpack.io' }
+        jcenter()
     }
 }


### PR DESCRIPTION
caused by `com.jaredsburrows:gradle-license-plugin:0.8.90` transitive fetch of `implementation 'org.jetbrains.kotlinx:kotlinx-html-js:0.7.2'`

fixes: #346 https://github.com/adrcotfas/Goodtime/issues/346